### PR TITLE
fix issue with bootstrap like class names

### DIFF
--- a/lib/purifycss.es.js
+++ b/lib/purifycss.es.js
@@ -780,7 +780,7 @@ var getAllWordsInContent = function getAllWordsInContent(content) {
         html: true,
         body: true
     };
-    var words = content.split(/[^a-z]/g);
+    var words = content.split(/[^A-z\-0-9\_]/g);
     var _iteratorNormalCompletion = true;
     var _didIteratorError = false;
     var _iteratorError = undefined;
@@ -811,10 +811,10 @@ var getAllWordsInContent = function getAllWordsInContent(content) {
 
 var getAllWordsInSelector = function getAllWordsInSelector(selector) {
     // Remove attr selectors. "a[href...]"" will become "a".
-    selector = selector.replace(/\[(.+?)\]/g, "").toLowerCase();
+    selector = selector.replace(/\[(.+?)\]/g, "").toLowerCase
     // If complex attr selector (has a bracket in it) just leave
     // the selector in. ¯\_(ツ)_/¯
-    if (selector.includes("[") || selector.includes("]")) {
+    ();if (selector.includes("[") || selector.includes("]")) {
         return [];
     }
     var skipNextWord = false,
@@ -837,7 +837,7 @@ var getAllWordsInSelector = function getAllWordsInSelector(selector) {
                 skipNextWord = true;
                 continue;
             }
-            if (/[a-z]/.test(letter)) {
+            if (/[A-z\-0-9\_]/.test(letter)) {
                 word += letter;
             } else {
                 addWord(words, word);
@@ -865,7 +865,7 @@ var getAllWordsInSelector = function getAllWordsInSelector(selector) {
 };
 
 var isWildcardWhitelistSelector = function isWildcardWhitelistSelector(selector) {
-    return selector[0] === "*" && selector[selector.length - 1] === "*";
+    return selector.indexOf('*') >= 0 ? selector : false;
 };
 
 var hasWhitelistMatch = function hasWhitelistMatch(selector, whitelist) {
@@ -877,7 +877,7 @@ var hasWhitelistMatch = function hasWhitelistMatch(selector, whitelist) {
         for (var _iterator = whitelist[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
             var el = _step.value;
 
-            if (selector.includes(el)) return true;
+            if (new RegExp('^' + el.replace(/\*/g, '\\S*').replace(/\./g, '\\.') + '$', 'm').test(selector.replace(/^\s|\s$/g, ''))) return true;
         }
     } catch (err) {
         _didIteratorError = true;
@@ -908,21 +908,22 @@ var SelectorFilter = function () {
     }
 
     createClass(SelectorFilter, [{
-        key: "initialize",
+        key: 'initialize',
         value: function initialize(CssSyntaxTree) {
             CssSyntaxTree.on("readRule", this.parseRule.bind(this));
         }
     }, {
-        key: "parseWhitelist",
+        key: 'parseWhitelist',
         value: function parseWhitelist(whitelist) {
             var _this = this;
 
             whitelist.forEach(function (whitelistSelector) {
                 whitelistSelector = whitelistSelector.toLowerCase();
 
-                if (isWildcardWhitelistSelector(whitelistSelector)) {
-                    // If '*button*' then push 'button' onto list.
-                    _this.wildcardWhitelist.push(whitelistSelector.substr(1, whitelistSelector.length - 2));
+                var wildCard = isWildcardWhitelistSelector(whitelistSelector);
+                if (wildCard) {
+                    // If '*button' or 'button*' then push the wildcard onto list.
+                    _this.wildcardWhitelist.push(wildCard);
                 } else {
                     getAllWordsInSelector(whitelistSelector).forEach(function (word) {
                         _this.contentWords[word] = true;
@@ -931,12 +932,12 @@ var SelectorFilter = function () {
             });
         }
     }, {
-        key: "parseRule",
+        key: 'parseRule',
         value: function parseRule(selectors, rule) {
             rule.selectors = this.filterSelectors(selectors);
         }
     }, {
-        key: "filterSelectors",
+        key: 'filterSelectors',
         value: function filterSelectors(selectors) {
             var contentWords = this.contentWords,
                 rejectedSelectors = this.rejectedSelectors,

--- a/lib/purifycss.js
+++ b/lib/purifycss.js
@@ -784,7 +784,7 @@ var getAllWordsInContent = function getAllWordsInContent(content) {
         html: true,
         body: true
     };
-    var words = content.split(/[^a-z]/g);
+    var words = content.split(/[^A-z\-0-9\_]/g);
     var _iteratorNormalCompletion = true;
     var _didIteratorError = false;
     var _iteratorError = undefined;
@@ -815,10 +815,10 @@ var getAllWordsInContent = function getAllWordsInContent(content) {
 
 var getAllWordsInSelector = function getAllWordsInSelector(selector) {
     // Remove attr selectors. "a[href...]"" will become "a".
-    selector = selector.replace(/\[(.+?)\]/g, "").toLowerCase();
+    selector = selector.replace(/\[(.+?)\]/g, "").toLowerCase
     // If complex attr selector (has a bracket in it) just leave
     // the selector in. ¯\_(ツ)_/¯
-    if (selector.includes("[") || selector.includes("]")) {
+    ();if (selector.includes("[") || selector.includes("]")) {
         return [];
     }
     var skipNextWord = false,
@@ -841,7 +841,7 @@ var getAllWordsInSelector = function getAllWordsInSelector(selector) {
                 skipNextWord = true;
                 continue;
             }
-            if (/[a-z]/.test(letter)) {
+            if (/[A-z\-0-9\_]/.test(letter)) {
                 word += letter;
             } else {
                 addWord(words, word);
@@ -869,7 +869,7 @@ var getAllWordsInSelector = function getAllWordsInSelector(selector) {
 };
 
 var isWildcardWhitelistSelector = function isWildcardWhitelistSelector(selector) {
-    return selector[0] === "*" && selector[selector.length - 1] === "*";
+    return selector.indexOf('*') >= 0 ? selector : false;
 };
 
 var hasWhitelistMatch = function hasWhitelistMatch(selector, whitelist) {
@@ -881,7 +881,7 @@ var hasWhitelistMatch = function hasWhitelistMatch(selector, whitelist) {
         for (var _iterator = whitelist[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
             var el = _step.value;
 
-            if (selector.includes(el)) return true;
+            if (new RegExp('^' + el.replace(/\*/g, '\\S*').replace(/\./g, '\\.') + '$', 'm').test(selector.replace(/^\s|\s$/g, ''))) return true;
         }
     } catch (err) {
         _didIteratorError = true;
@@ -912,21 +912,22 @@ var SelectorFilter = function () {
     }
 
     createClass(SelectorFilter, [{
-        key: "initialize",
+        key: 'initialize',
         value: function initialize(CssSyntaxTree) {
             CssSyntaxTree.on("readRule", this.parseRule.bind(this));
         }
     }, {
-        key: "parseWhitelist",
+        key: 'parseWhitelist',
         value: function parseWhitelist(whitelist) {
             var _this = this;
 
             whitelist.forEach(function (whitelistSelector) {
                 whitelistSelector = whitelistSelector.toLowerCase();
 
-                if (isWildcardWhitelistSelector(whitelistSelector)) {
-                    // If '*button*' then push 'button' onto list.
-                    _this.wildcardWhitelist.push(whitelistSelector.substr(1, whitelistSelector.length - 2));
+                var wildCard = isWildcardWhitelistSelector(whitelistSelector);
+                if (wildCard) {
+                    // If '*button' or 'button*' then push the wildcard onto list.
+                    _this.wildcardWhitelist.push(wildCard);
                 } else {
                     getAllWordsInSelector(whitelistSelector).forEach(function (word) {
                         _this.contentWords[word] = true;
@@ -935,12 +936,12 @@ var SelectorFilter = function () {
             });
         }
     }, {
-        key: "parseRule",
+        key: 'parseRule',
         value: function parseRule(selectors, rule) {
             rule.selectors = this.filterSelectors(selectors);
         }
     }, {
-        key: "filterSelectors",
+        key: 'filterSelectors',
         value: function filterSelectors(selectors) {
             var contentWords = this.contentWords,
                 rejectedSelectors = this.rejectedSelectors,

--- a/src/SelectorFilter.js
+++ b/src/SelectorFilter.js
@@ -1,12 +1,12 @@
 import { getAllWordsInSelector } from "./utils/ExtractWordsUtil"
 
 const isWildcardWhitelistSelector = selector => {
-    return selector[0] === "*" && selector[selector.length - 1] === "*"
+    return selector.indexOf('*') >= 0 ? selector : false
 }
 
 const hasWhitelistMatch = (selector, whitelist) => {
     for (let el of whitelist) {
-        if (selector.includes(el)) return true
+        if ((new RegExp('^' + el.replace(/\*/g, '\\S*').replace(/\./g, '\\.') + '$', 'm')).test(selector.replace(/^\s|\s$/g, ''))) return true
     }
     return false
 }
@@ -27,11 +27,10 @@ class SelectorFilter {
         whitelist.forEach(whitelistSelector => {
             whitelistSelector = whitelistSelector.toLowerCase()
 
-            if (isWildcardWhitelistSelector(whitelistSelector)) {
-                // If '*button*' then push 'button' onto list.
-                this.wildcardWhitelist.push(
-                    whitelistSelector.substr(1, whitelistSelector.length - 2)
-                )
+            let wildCard = isWildcardWhitelistSelector(whitelistSelector);
+            if (wildCard) {
+                // If '*button' or 'button*' then push the wildcard onto list.
+                this.wildcardWhitelist.push(wildCard)
             } else {
                 getAllWordsInSelector(whitelistSelector).forEach(word => {
                     this.contentWords[word] = true

--- a/src/utils/ExtractWordsUtil.js
+++ b/src/utils/ExtractWordsUtil.js
@@ -8,7 +8,7 @@ export const getAllWordsInContent = content => {
         html: true,
         body: true
     }
-    const words = content.split(/[^a-z]/g)
+    const words = content.split(/[^A-z\-0-9\_]/g)
     for (let word of words) {
         used[word] = true
     }
@@ -36,7 +36,7 @@ export const getAllWordsInSelector = selector => {
             skipNextWord = true
             continue
         }
-        if (/[a-z]/.test(letter)) {
+        if (/[A-z\-0-9\_]/.test(letter)) {
             word += letter
         } else {
             addWord(words, word)


### PR DESCRIPTION
Allow not only: specificclass
but also: specific-class likeABootstrap for_example col-xs-12
and real regex